### PR TITLE
Fix field access deprecation warning

### DIFF
--- a/src/getthing.jl
+++ b/src/getthing.jl
@@ -30,7 +30,7 @@ function getthing(mod::Module, name::Vector{Symbol}, default = nothing)
   thing = mod
   for sym in name
     if isdefined(thing, sym)
-      thing = thing.(sym)
+      thing = getfield(thing, sym)
     else
       return default
     end


### PR DESCRIPTION
This should work with no warnings on release and nightly now.

There are no package tests but it worked properly in LightGraphs.