### PR TITLE
Uses multiple tasks for calling into an old world

### DIFF
--- a/src/Requires.jl
+++ b/src/Requires.jl
@@ -3,6 +3,7 @@ __precompile__()
 module Requires
 
 include("init.jl")
+include("oldcall.jl")
 include("getthing.jl")
 include("require.jl")
 

--- a/src/oldcall.jl
+++ b/src/oldcall.jl
@@ -1,0 +1,30 @@
+###
+# Tasks are frozen at their worldage and we can use them
+# to call previous versions of functions. The code below
+# is taken from test/worlds.jl in JuliaLang/julia
+###
+
+# The maximum number of tasks that can be used for recursive
+# loading, if Julia freezes it might be because this number
+# is to low.
+const MAX_TASKS = 16
+
+function wfunc(channel)
+  for (f, args, c) in channel
+    try
+      f(args...)
+      notify(c)
+    catch err
+      notify(c, val=err, error=true)
+    end
+  end
+end
+
+@init let (chnls, tasks) = Base.channeled_tasks(1, ntuple(i->wfunc, MAX_TASKS)...)
+global oldcall
+function oldcall(f, args...)
+  c = Condition()
+  put!(chnls[1], (f, args, c))
+  wait(c)
+end
+end


### PR DESCRIPTION
Fixes the longer example in #30. The problem is that `Base.require` uses eval and thus switches into a newer age. We need to provide enough tasks so that we can switch back (the previous tasks get blocked while doing so).

cc: @davidanthoff 