### PR TITLE
yield before processing calling f in oldcall

### DIFF
--- a/src/oldcall.jl
+++ b/src/oldcall.jl
@@ -12,6 +12,7 @@ const MAX_TASKS = 16
 function wfunc(channel)
   for (f, args, c) in channel
     try
+      yield()
       f(args...)
       notify(c)
     catch err


### PR DESCRIPTION
Otherwise we seem to prevent other tasks from running.

fixes #34 