### PR TITLE
Add test for #48

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,1 @@
-JSON
+Colors

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ function writepkg(name, precomp::Bool, submod::Bool)
             println(io, """
                 export SubModule
                 module SubModule
-                    using JSON
+                    using Colors
                     flag = true
                 end
             """)
@@ -32,7 +32,7 @@ using Requires
 flag = false
 
 function __init__()
-    @require JSON="682c06a0-de6a-54ab-a142-c8b1cf79cde6" begin
+    @require Colors="5ae59095-9a9b-59fe-a467-6f913c188581" begin
         $(action)
     end
 end
@@ -77,7 +77,7 @@ end
         @eval using FooSubPC
         @test !(:SubModule in names(FooSubPC))
 
-        @eval using JSON
+        @eval using Colors
 
         @test FooNPC.flag
         @test FooPC.flag

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,26 @@
 using Test
 
-function writepkg(name, precomp::Bool)
+function writepkg(name, precomp::Bool, submod::Bool)
+    action = """
+        global flag = true
+    """
+
+    if submod
+        open("$(name)_submod.jl", "w") do io
+            println(io, """
+                export SubModule
+                module SubModule
+                    using JSON
+                    flag = true
+                end
+            """)
+        end
+
+        action *= """
+            include("$(name)_submod.jl")
+        """
+    end
+
     open("$name.jl", "w") do io
         println(io, """
 __precompile__($precomp)
@@ -12,7 +32,9 @@ using Requires
 flag = false
 
 function __init__()
-    @require JSON="682c06a0-de6a-54ab-a142-c8b1cf79cde6" global flag = true
+    @require JSON="682c06a0-de6a-54ab-a142-c8b1cf79cde6" begin
+        $(action)
+    end
 end
 
 end
@@ -26,12 +48,22 @@ end
             npcdir = joinpath("FooNPC", "src")
             mkpath(npcdir)
             cd(npcdir) do
-                writepkg("FooNPC", false)
+                writepkg("FooNPC", false, false)
             end
             npcdir = joinpath("FooPC", "src")
             mkpath(npcdir)
             cd(npcdir) do
-                writepkg("FooPC", true)
+                writepkg("FooPC", true, false)
+            end
+            npcdir = joinpath("FooSubNPC", "src")
+            mkpath(npcdir)
+            cd(npcdir) do
+                writepkg("FooSubNPC", false, true)
+            end
+            npcdir = joinpath("FooSubPC", "src")
+            mkpath(npcdir)
+            cd(npcdir) do
+                writepkg("FooSubPC", true, true)
             end
         end
         push!(LOAD_PATH, pkgsdir)
@@ -40,28 +72,52 @@ end
         @test !FooNPC.flag
         @eval using FooPC
         @test !FooPC.flag
+        @eval using FooSubNPC
+        @test !(:SubModule in names(FooSubNPC))
+        @eval using FooSubPC
+        @test !(:SubModule in names(FooSubPC))
 
         @eval using JSON
 
         @test FooNPC.flag
         @test FooPC.flag
+        @test :SubModule in names(FooSubNPC)
+        @test FooSubNPC.SubModule.flag
+        @test :SubModule in names(FooSubPC)
+        @test FooSubPC.SubModule.flag
 
         cd(pkgsdir) do
             npcdir = joinpath("FooAfterNPC", "src")
             mkpath(npcdir)
             cd(npcdir) do
-                writepkg("FooAfterNPC", false)
+                writepkg("FooAfterNPC", false, false)
             end
             pcidr = joinpath("FooAfterPC", "src")
             mkpath(pcidr)
             cd(pcidr) do
-                writepkg("FooAfterPC", true)
+                writepkg("FooAfterPC", true, false)
+            end
+            sanpcdir = joinpath("FooSubAfterNPC", "src")
+            mkpath(sanpcdir)
+            cd(sanpcdir) do
+                writepkg("FooSubAfterNPC", false, true)
+            end
+            sapcdir = joinpath("FooSubAfterPC", "src")
+            mkpath(sapcdir)
+            cd(sapcdir) do
+                writepkg("FooSubAfterPC", true, true)
             end
         end
 
         @eval using FooAfterNPC
         @eval using FooAfterPC
+        @eval using FooSubAfterNPC
+        @eval using FooSubAfterPC
         @test FooAfterNPC.flag
         @test FooAfterPC.flag
+        @test :SubModule in names(FooSubAfterNPC)
+        @test FooSubAfterNPC.SubModule.flag
+        @test :SubModule in names(FooSubAfterPC)
+        @test FooSubAfterPC.SubModule.flag
     end
 end


### PR DESCRIPTION
Adds the tests related to issue #48 and the change made in #49.

~I tried making sure these test fail when the change in #48 is reverted, but I couldn't get it to trigger. I don't know if I'm just invoking `pkg> test Requires` from the wrong environment (i.e. it's just pulling Requires v0.5.2 back in) or maybe there's a difference related to Pkg2 vs Pkg3 style environments — I was initially running into the bug for some code I was adding a `Project.toml` and trying to sort out how sub-projects should be structured...~ (See comments below.)