### PR TITLE
improve callback performance

### DIFF
--- a/src/require.jl
+++ b/src/require.jl
@@ -16,7 +16,7 @@ listenpkg(f, pkg) =
 function loadpkg(pkg)
   fs = callbacks(pkg)
   delete!(_callbacks, pkg)
-  map(f->Base.invokelatest(f), fs)
+  foreach(Base.invokelatest, fs)
 end
 
 function withpath(f, path)

--- a/src/require.jl
+++ b/src/require.jl
@@ -14,9 +14,11 @@ listenpkg(f, pkg) =
   loaded(pkg) ? f() : push!(callbacks(pkg), f)
 
 function loadpkg(pkg)
-  fs = callbacks(pkg)
-  delete!(_callbacks, pkg)
-  foreach(Base.invokelatest, fs)
+  if haskey(_callbacks, pkg)
+    fs = _callbacks[pkg]
+    delete!(_callbacks, pkg)
+    foreach(Base.invokelatest, fs)
+  end
 end
 
 function withpath(f, path)


### PR DESCRIPTION
Before:

```
julia> @time Base.invokelatest(Requires.loadpkg, pkgids[4])
  0.051562 seconds (125.03 k allocations: 6.398 MiB)
```

after:

```
julia> @time Base.invokelatest(Requires.loadpkg, pkgids[4])
  0.025036 seconds (31.71 k allocations: 1.527 MiB)
```