### PR TITLE
Support package notifications

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,8 +1,11 @@
 name = "Requires"
 uuid = "ae029012-a4dd-5104-9daa-d747884805df"
 
+[deps]
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
 [compat]
-julia = "≥ 0.7.0"
+julia = "0.7, 1"
 
 [extras]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/README.md
+++ b/README.md
@@ -95,3 +95,24 @@ RGB{N0f8}(1.0,0.0,0.0)
 ```
 
 Note that if `Reqs` were a registered package you could replace the first two commands with `using Reqs`.
+
+## Receiving notifications in other packages
+
+Other packages can be informed about Requires' actions. To implement this, add a function
+
+```julia
+add_require(sourcefile, modcaller, id, modname, expr)
+```
+
+to your package. The arguments will have the following types:
+
+- `sourcefile`: a string, the full path to the file that contained the `@require` statement
+- `modcaller`: the active module from which the `@require` was issued
+- `id`: a string representing the UUID of the package that triggered this `@require` block (e.g.,
+  the uuid string from `@require Gadfly="c91e804a-d5a3-530f-b6f0-dfbca275c004"`)
+- `modname`: a string representing the name of the package that triggered this `@require` block
+  (e.g., `"Gadfly"` in the example above)
+- `expr`: the expression in the `@require` block
+
+Once you've added this, append the `PkgId` of your package to `Requires.notified_pkgs`
+in a pull request to Requires.

--- a/src/Requires.jl
+++ b/src/Requires.jl
@@ -1,6 +1,6 @@
-__precompile__()
-
 module Requires
+
+using UUIDs
 
 include("init.jl")
 include("require.jl")


### PR DESCRIPTION
This is motivated by wanting integration with Revise. However, I implemented it as a general mechanism in case other packages want similar integration. The companion PR is in Revise https://github.com/timholy/Revise.jl/pull/387.

Note that this includes a couple of updates, of which the only important one is upper-bounding Julia at version 1.x. This is necessary for automatic merging of registrations.